### PR TITLE
indexer-gateway: fix formatting

### DIFF
--- a/api-references/indexer-gateway/examples/get-balance-updates.mdx
+++ b/api-references/indexer-gateway/examples/get-balance-updates.mdx
@@ -19,7 +19,7 @@ description: This content provides instructions on fetching balance updates from
 
 Example: query balance updates of the USDT contract on Ethereum network.
 
-:::code-group
+<CodeGroup>
 
 ```shell [Curl]
 curl -X POST \
@@ -122,4 +122,4 @@ func main() {
 	}
 }
 ```
-:::
+</CodeGroup>

--- a/api-references/indexer-gateway/examples/get-native-token-balances.mdx
+++ b/api-references/indexer-gateway/examples/get-native-token-balances.mdx
@@ -24,7 +24,7 @@ balances](/api-references/indexer/examples/native-network-balance) example for I
 Example: Get the native balances of an account address across all chains with a
 single query
 
-:::code-group
+<CodeGroup>
 
 ```shell [Curl]
 curl -X POST \
@@ -112,4 +112,5 @@ func main() {
 	}
 }
 ```
-:::
+
+</CodeGroup>

--- a/api-references/indexer-gateway/examples/get-token-balances-by-contract.mdx
+++ b/api-references/indexer-gateway/examples/get-token-balances-by-contract.mdx
@@ -30,7 +30,7 @@ Example: Retrieve USDC token balances for a specific account (
 * USDC on Polygon `0x3c499c542cef5e3811e1192ce70d8cc03d5c3359`
 * USDC on BSC `0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d`
 
-:::code-group
+<CodeGroup>
 
 ```shell [Curl]
 curl -X POST \
@@ -144,4 +144,4 @@ func main() {
 	}
 }
 ```
-:::
+</CodeGroup>

--- a/api-references/indexer-gateway/examples/get-token-balances-details.mdx
+++ b/api-references/indexer-gateway/examples/get-token-balances-details.mdx
@@ -41,7 +41,7 @@ In the following examples, we're going to use the `GetTokenBalancesSummary` and
 Example: Get the summary of all verified token balances for a specific account
 on `mainnet` and `polygon`
 
-:::code-group
+<CodeGroup>
 
 ```shell [Curl]
 curl -X POST \
@@ -161,7 +161,7 @@ func main() {
 	}
 }
 ```
-:::
+</CodeGroup>
 
 
 ### Get balance details of specific contracts on all networks
@@ -170,7 +170,7 @@ func main() {
 Example: Get the balance details of the USDC contracts on Arbitrum, Polygon and
 Mainne
 
-:::code-group
+<CodeGroup>
 
 ```shell [Curl]
 curl -X POST \
@@ -309,4 +309,4 @@ func main() {
 }
 ```
 
-:::
+</CodeGroup>

--- a/api-references/indexer-gateway/examples/get-token-balances.mdx
+++ b/api-references/indexer-gateway/examples/get-token-balances.mdx
@@ -33,7 +33,7 @@ example](/api-references/indexer/examples/fetch-tokens) for Indexer.
 Example: Retrieve token balances, along metadata for the
 `0x8e3E38fe7367dd3b52D1e281E4e8400447C8d8B9` account across all chains.
 
-:::code-group
+<CodeGroup>
 
 ```shell [Curl]
 curl -X POST \
@@ -162,24 +162,26 @@ ChainID: 1 -> 7 tokens found
         Token: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" ("USDC"): 221887067
 */
 ```
-:::
+</CodeGroup>
 
 <br />
 
-:::info[PRO TIP: fetching ERC721/1155 token IDs]
+<Note>
+**PRO TIP: fetching ERC721/1155 token IDs**
+
 You'll notice that, by default, `GetTokenBalances` will return at most one
 token instance from each contract.  In order to fetch ERC721/1155 token
 balances, you must pass the `contractAddress` to the `GetTokenBalances` method.
 This will return all of the tokens owned by `accountAddress` from the specified
 `contractAddress`.  See section below for more information.
-:::
+</Note>
 
 ### Fetch token IDs, balances and metadata of ERC721 and ERC1155 collections.
 
 Example: fetch token balances for a specific account and token contract on the
 Polygon network
 
-:::code-group
+<CodeGroup>
 
 ```shell [Curl]
 curl -X POST \
@@ -299,4 +301,4 @@ func main() {
 }
 ```
 
-:::
+</CodeGroup>


### PR DESCRIPTION
Some errors were preventing the indexer gateway docs from showing up correctly:

![Screenshot From 2025-03-14 10-19-56](https://github.com/user-attachments/assets/7735c181-29f9-4697-970f-6e37208412c0)

This PR fixes those details:

![Screenshot From 2025-03-14 11-30-17](https://github.com/user-attachments/assets/05bd82f2-55a2-4fdf-b1c9-dcdf168e6ee3)
