### PR TITLE
update github link for web-sdk

### DIFF
--- a/es/guides/template-overview.mdx
+++ b/es/guides/template-overview.mdx
@@ -2,7 +2,7 @@
 title: Plantillas
 description: Resumen de plantillas para la documentación de Sequence
 mode: wide
-sidebarTitle: Resumen
+sidebarTitle: Descripción general
 ---
 
 Inicie su integración con Sequence con nuestros demos, ejemplos y boilerplates de código abierto para acelerar su salida al mercado.
@@ -53,7 +53,7 @@ Aplicación de ejemplo creada con nuestro Unreal SDK, mostrando el Embedded Wall
 Implementación de ejemplo en React y NextJS mostrando varios patrones comunes usando Web SDK como firma de mensajes, envío de transacciones, visualización de inventario o minteo de un NFT.
 
 <CardGroup cols={2}>
-  <Card title="Repositorio" icon="github" href="https://github.com/0xsequence/kit/tree/master/examples" horizontal />
+  <Card title="Repositorio" icon="github" href="https://github.com/0xsequence/web-sdk/tree/master/examples" horizontal />
 
   <Card title="Demo" icon="globe" href="https://0xsequence.github.io/kit/" horizontal />
 </CardGroup>

--- a/guides/template-overview.mdx
+++ b/guides/template-overview.mdx
@@ -41,7 +41,7 @@ Example application made with our Unreal SDK, showcasing embedded wallet integra
 ### End to End playground for Web SDK
 Example implementation in React & NextJS showcasing various common patterns using Web SDK such as signingv messages, sending transactions, displaying inventory, or minting an NFT.
 <CardGroup cols={2}>
-  <Card title="Repo" icon="github" href="https://github.com/0xsequence/kit/tree/master/examples" horizontal />
+  <Card title="Repo" icon="github" href="https://github.com/0xsequence/web-sdk/tree/master/examples" horizontal />
   <Card title="Demo" icon="globe" href="https://0xsequence.github.io/kit/" horizontal />
 </CardGroup>
 

--- a/ja/guides/template-overview.mdx
+++ b/ja/guides/template-overview.mdx
@@ -53,7 +53,7 @@ Unreal SDKを使い、Embedded Walletでメッセージ署名やERC20トラン�
 React & NextJSでの実装例。Web SDKを使ったメッセージ署名、トランザクション送信、インベントリ表示、NFTミントなどの一般的なパターンを紹介します。
 
 <CardGroup cols={2}>
-  <Card title="リポジトリ" icon="github" href="https://github.com/0xsequence/kit/tree/master/examples" horizontal />
+  <Card title="リポジトリ" icon="github" href="https://github.com/0xsequence/web-sdk/tree/master/examples" horizontal />
 
   <Card title="デモ" icon="globe" href="https://0xsequence.github.io/kit/" horizontal />
 </CardGroup>


### PR DESCRIPTION
change 
https://github.com/0xsequence/kit/tree/master/examples (broken)

to
https://github.com/0xsequence/web-sdk/tree/master/examples