### PR TITLE
Enhance documentation for useMakeOfferModal hook

### DIFF
--- a/es/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
+++ b/es/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
@@ -115,6 +115,11 @@ interface ShowMakeOfferModalArgs {
 | `orderbookKind`     | `OrderbookKind` | Opcional. El orderbook del marketplace a utilizar (por defecto es `sequence_marketplace_v2`) |
 
 #### Valores de OrderbookKind
+Puede importar el tipo `OrderbookKind` desde el SDK de marketplace:
+
+```typescript
+import { OrderbookKind } from "@0xsequence/marketplace-sdk";
+```
 
 ```typescript
 enum OrderbookKind {

--- a/es/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
+++ b/es/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
@@ -1,60 +1,149 @@
 ---
 title: useMakeOfferModal
-description: El hook useMakeOfferModal permite a los usuarios hacer una oferta por un NFT. Facilita la creación y el envío de ofertas dentro del Marketplace.
+description: Hook para gestionar la interfaz del modal de creación de ofertas en coleccionables
 sidebarTitle: useMakeOfferModal
 ---
 
-```ts
+## Importar
+
+```typescript
 import { useMakeOfferModal } from "@0xsequence/marketplace-sdk/react";
-
-## Into your React component:
-
-const { show: showOfferModal } = useMakeOfferModal({
-	onError,
-});
-
-const onClickOffer = () => {
-	showOfferModal({
-		collectionAddress,
-		chainId,
-		collectibleId,
-		orderbookKind,
-	});
-};
-
-return <button onClick={onClickOffer}>Make Offer</button>
 ```
 
-<ResponseField name="useMakeOfferModal">
-  <ResponseField name="* params" />
+## Uso
 
-  <Expandable>
-    ```ts
-    interface useMakeOfferModal {
-    	onSuccess?: ({ hash, orderId }: {
-    			hash?: Hash;
-    			orderId?: string;
-    	}) => void;
-    	onError?: (error: Error) => void;
-    }
-    ```
-  </Expandable>
+<Note>
+  Asegúrese de haber seguido la guía de [Primeros pasos](https://docs.sequence.xyz/sdk/marketplace-sdk/getting-started) para obtener la dirección de la colección y el chainId.
+</Note>
 
-  <ResponseField name="* return properties" />
+### Ejemplo
+Ejemplo de cómo implementar la funcionalidad de crear una oferta usando el hook `useMakeOfferModal`:
 
-  <Expandable>
-    <ResponseField name="show" type="(args: ShowMakeOfferModalArgs) => void">
-      ```ts
-      interface ShowMakeOfferModalArgs {
-      	collectionAddress: Hex;
-      	chainId: string;
-      	collectibleId: string;
-      	orderbookKind?: OrderbookKind;
-      	callbacks?: ModalCallbacks;
-      }
-      ```
-    </ResponseField>
+```typescript
+export default function MakeOfferExample() {
+  const { data: marketplaceConfig, isLoading: isMarketplaceConfigLoading } =
+    useMarketplaceConfig();
 
-    <ResponseField name="close" type="() => void" />
-  </Expandable>
-</ResponseField>
+  const collection = marketplaceConfig?.market.collections[0];
+  const chainId = collection?.chainId as number;
+  const collectionAddress = collection?.itemsAddress as Address;
+  const collectibleId = '0';
+  const orderbookKind = collection?.destinationMarketplace;
+
+  const { show: showMakeOfferModal } = useMakeOfferModal({
+    onSuccess: ({ hash }) => {
+      console.log('Offer created successfully', { hash });
+    },
+    onError: (error) => {
+      console.error('Failed to create offer:', error.message);
+    },
+  });
+
+  const handleMakeOffer = () => {
+    showMakeOfferModal({
+      chainId,
+      collectionAddress,
+      collectibleId,
+      orderbookKind, // Optional - defaults to sequence_marketplace_v2
+    });
+  };
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h3>Make Offer</h3>
+
+      <button
+        type="button"
+        onClick={handleMakeOffer}
+        disabled={isMarketplaceConfigLoading}
+      >
+        Make Offer
+      </button>
+    </div>
+  );
+}
+```
+
+## Parámetros
+El hook acepta un objeto opcional `callbacks` con las siguientes propiedades:
+
+```typescript
+interface ModalCallbacks {
+  onSuccess?: ({ hash, orderId }: { hash?: Hash; orderId?: string }) => void;
+  onError?: (error: Error) => void;
+  successActionButtons?: Array<{ label: string; action: () => void }>;
+}
+```
+
+| Parámetro                        | Type                                                             | Description                                                                                     |
+| -------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `callbacks.onSuccess`            | `({ hash, orderId }: { hash?: Hash; orderId?: string }) => void` | Función de callback opcional que se ejecuta cuando la oferta se crea exitosamente               |
+| `callbacks.onError`              | `(error: Error) => void`                                         | Función de callback opcional que se ejecuta si ocurre un error durante la creación de la oferta |
+| `callbacks.successActionButtons` | `Array<{ label: string; action: () => void }>`                   | Arreglo opcional de botones de acción para mostrar en caso de éxito                             |
+
+## Tipo de retorno
+El hook retorna un objeto con los siguientes métodos:
+
+```typescript
+{
+  show: (args: ShowMakeOfferModalArgs) => void
+  close: () => void
+}
+```
+
+### Métodos
+
+#### show
+`(args: ShowMakeOfferModalArgs) => void`
+
+Abre el modal de creación de ofertas con los parámetros especificados.
+
+```typescript
+interface ShowMakeOfferModalArgs {
+  collectionAddress: Address;
+  chainId: number;
+  collectibleId: string;
+  orderbookKind?: OrderbookKind;
+}
+```
+
+| Parámetro           | Type            | Description                                                                                  |
+| ------------------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `collectionAddress` | `Address`       | La dirección del contrato de la colección NFT                                                |
+| `chainId`           | `number`        | El chain ID de la red blockchain donde existe la colección                                   |
+| `collectibleId`     | `string`        | El token ID del coleccionable específico al que se le quiere hacer una oferta                |
+| `orderbookKind`     | `OrderbookKind` | Opcional. El orderbook del marketplace a utilizar (por defecto es `sequence_marketplace_v2`) |
+
+#### Valores de OrderbookKind
+
+```typescript
+enum OrderbookKind {
+  unknown = "unknown",
+  sequence_marketplace_v1 = "sequence_marketplace_v1",
+  sequence_marketplace_v2 = "sequence_marketplace_v2",
+  blur = "blur",
+  opensea = "opensea",
+  looks_rare = "looks_rare",
+}
+```
+
+#### close
+`() => void`
+
+Cierra el modal de creación de ofertas.
+
+## Notas
+El hook `useMakeOfferModal` ofrece una forma práctica de gestionar la interfaz del modal para crear ofertas en coleccionables. Se encarga de:
+- Abrir y cerrar el modal
+- Gestionar el estado del flujo de creación de la oferta
+- Aprobar el token para la moneda de la oferta (si es necesario)
+- Manejo de errores y callbacks de éxito
+- Soporte para diferentes orderbooks de marketplace
+- Gestión de la fecha de expiración de la oferta (por defecto, 7 días)
+- Selección de moneda y validación del precio ingresado
+
+El modal permite a los usuarios:
+- Seleccionar el precio y la moneda de la oferta
+- Definir la cantidad de la oferta (para tokens ERC-1155)
+- Elegir una fecha de expiración para la oferta
+- Completar las transacciones necesarias en blockchain (aprobación + creación de la oferta)

--- a/ja/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
+++ b/ja/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
@@ -115,6 +115,11 @@ interface ShowMakeOfferModalArgs {
 | `orderbookKind`     | `OrderbookKind` | 任意。使用するマーケットプレイスのオーダーブック（デフォルトは `sequence_marketplace_v2`） |
 
 #### OrderbookKind の値
+`OrderbookKind` 型は、マーケットプレイスSDKからインポートできます。
+
+```typescript
+import { OrderbookKind } from "@0xsequence/marketplace-sdk";
+```
 
 ```typescript
 enum OrderbookKind {

--- a/ja/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
+++ b/ja/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
@@ -1,60 +1,149 @@
 ---
 title: useMakeOfferModal
-description: useMakeOfferModalフックは、ユーザーがNFTに対してオファーを出すことを可能にします。マーケットプレイス内でオファーの作成と送信をサポートします。
+description: コレクティブルへのオファー作成用モーダルインターフェースを管理するためのフック
 sidebarTitle: useMakeOfferModal
 ---
 
-```ts
+## インポート
+
+```typescript
 import { useMakeOfferModal } from "@0xsequence/marketplace-sdk/react";
-
-## Into your React component:
-
-const { show: showOfferModal } = useMakeOfferModal({
-	onError,
-});
-
-const onClickOffer = () => {
-	showOfferModal({
-		collectionAddress,
-		chainId,
-		collectibleId,
-		orderbookKind,
-	});
-};
-
-return <button onClick={onClickOffer}>Make Offer</button>
 ```
 
-<ResponseField name="useMakeOfferModal">
-  <ResponseField name="* params" />
+## 使い方
 
-  <Expandable>
-    ```ts
-    interface useMakeOfferModal {
-    	onSuccess?: ({ hash, orderId }: {
-    			hash?: Hash;
-    			orderId?: string;
-    	}) => void;
-    	onError?: (error: Error) => void;
-    }
-    ```
-  </Expandable>
+<Note>
+  コレクションアドレスとchainIdを取得するために、必ず[Getting Started](https://docs.sequence.xyz/sdk/marketplace-sdk/getting-started)ガイドに従ってください。
+</Note>
 
-  <ResponseField name="* return properties" />
+### 例
+`useMakeOfferModal` フックを使ってオファー作成機能を実装する例：
 
-  <Expandable>
-    <ResponseField name="show" type="(args: ShowMakeOfferModalArgs) => void">
-      ```ts
-      interface ShowMakeOfferModalArgs {
-      	collectionAddress: Hex;
-      	chainId: string;
-      	collectibleId: string;
-      	orderbookKind?: OrderbookKind;
-      	callbacks?: ModalCallbacks;
-      }
-      ```
-    </ResponseField>
+```typescript
+export default function MakeOfferExample() {
+  const { data: marketplaceConfig, isLoading: isMarketplaceConfigLoading } =
+    useMarketplaceConfig();
 
-    <ResponseField name="close" type="() => void" />
-  </Expandable>
-</ResponseField>
+  const collection = marketplaceConfig?.market.collections[0];
+  const chainId = collection?.chainId as number;
+  const collectionAddress = collection?.itemsAddress as Address;
+  const collectibleId = '0';
+  const orderbookKind = collection?.destinationMarketplace;
+
+  const { show: showMakeOfferModal } = useMakeOfferModal({
+    onSuccess: ({ hash }) => {
+      console.log('Offer created successfully', { hash });
+    },
+    onError: (error) => {
+      console.error('Failed to create offer:', error.message);
+    },
+  });
+
+  const handleMakeOffer = () => {
+    showMakeOfferModal({
+      chainId,
+      collectionAddress,
+      collectibleId,
+      orderbookKind, // Optional - defaults to sequence_marketplace_v2
+    });
+  };
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h3>Make Offer</h3>
+
+      <button
+        type="button"
+        onClick={handleMakeOffer}
+        disabled={isMarketplaceConfigLoading}
+      >
+        Make Offer
+      </button>
+    </div>
+  );
+}
+```
+
+## パラメータ
+このフックは、オプションで以下のプロパティを持つ `callbacks` オブジェクトを受け取ります：
+
+```typescript
+interface ModalCallbacks {
+  onSuccess?: ({ hash, orderId }: { hash?: Hash; orderId?: string }) => void;
+  onError?: (error: Error) => void;
+  successActionButtons?: Array<{ label: string; action: () => void }>;
+}
+```
+
+| パラメータ                            | 型                                                                | 説明                                    |
+| -------------------------------- | ---------------------------------------------------------------- | ------------------------------------- |
+| `callbacks.onSuccess`            | `({ hash, orderId }: { hash?: Hash; orderId?: string }) => void` | オファーが正常に作成されたときに呼び出される、任意のコールバック関数    |
+| `callbacks.onError`              | `(error: Error) => void`                                         | オファー作成中にエラーが発生した場合に呼び出される、任意のコールバック関数 |
+| `callbacks.successActionButtons` | `Array<{ label: string; action: () => void }>`                   | 成功時に表示するアクションボタンのオプション配列              |
+
+## 返り値の型
+このフックは、以下のメソッドを持つオブジェクトを返します：
+
+```typescript
+{
+  show: (args: ShowMakeOfferModalArgs) => void
+  close: () => void
+}
+```
+
+### メソッド一覧
+
+#### show
+`(args: ShowMakeOfferModalArgs) => void`
+
+指定したパラメータでオファー作成用モーダルを開きます。
+
+```typescript
+interface ShowMakeOfferModalArgs {
+  collectionAddress: Address;
+  chainId: number;
+  collectibleId: string;
+  orderbookKind?: OrderbookKind;
+}
+```
+
+| パラメータ               | 型               | 説明                                                         |
+| ------------------- | --------------- | ---------------------------------------------------------- |
+| `collectionAddress` | `Address`       | NFTコレクションのコントラクトアドレス                                       |
+| `chainId`           | `number`        | コレクションが存在するブロックチェーンネットワークのチェーンID                           |
+| `collectibleId`     | `string`        | オファーを出す対象となる特定のコレクティブルのトークンID                              |
+| `orderbookKind`     | `OrderbookKind` | 任意。使用するマーケットプレイスのオーダーブック（デフォルトは `sequence_marketplace_v2`） |
+
+#### OrderbookKind の値
+
+```typescript
+enum OrderbookKind {
+  unknown = "unknown",
+  sequence_marketplace_v1 = "sequence_marketplace_v1",
+  sequence_marketplace_v2 = "sequence_marketplace_v2",
+  blur = "blur",
+  opensea = "opensea",
+  looks_rare = "looks_rare",
+}
+```
+
+#### close
+`() => void`
+
+オファー作成用モーダルを閉じます。
+
+## 補足
+`useMakeOfferModal` フックは、コレクティブルへのオファー作成用モーダルインターフェースを簡単に管理できる方法を提供します。主に以下を処理します：
+- モーダルの開閉
+- オファー作成フローの状態管理
+- オファー通貨のトークン承認（必要な場合）
+- エラー処理や成功時のコールバック対応
+- さまざまなマーケットプレイスのオーダーブックへの対応
+- オファーの有効期限管理（デフォルトは7日間）
+- 通貨の選択と価格入力のバリデーション
+
+このモーダルでは、ユーザーが以下を行えます：
+- オファー価格と通貨の選択
+- オファー数量の設定（ERC-1155トークンの場合）
+- オファーの有効期限を設定
+- 必要なブロックチェーントランザクション（承認＋オファー作成）を完了する

--- a/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
+++ b/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
@@ -122,6 +122,12 @@ interface ShowMakeOfferModalArgs {
 
 #### OrderbookKind Values
 
+You can import the `OrderbookKind` type from the marketplace SDK:
+
+```typescript
+import { OrderbookKind } from "@0xsequence/marketplace-sdk";
+```
+
 ```typescript
 enum OrderbookKind {
   unknown = "unknown",

--- a/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
+++ b/sdk/marketplace-sdk/hooks/marketplace-actions/useMakeOfferModal.mdx
@@ -1,56 +1,158 @@
 ---
-title: useMakeOfferModal
-description: The useMakeOfferModal hook enables users to place an offer on an NFT. It facilitates creating and submitting offers within the Marketplace.
-sidebarTitle: useMakeOfferModal
+title: "useMakeOfferModal"
+description: "Hook for managing the make offer modal interface for creating offers on collectibles"
+sidebarTitle: "useMakeOfferModal"
 ---
 
-```ts
+## Import
+
+```typescript
 import { useMakeOfferModal } from "@0xsequence/marketplace-sdk/react";
-
-## Into your React component:
-
-const { show: showOfferModal } = useMakeOfferModal({
-	onError,
-});
-
-const onClickOffer = () => {
-	showOfferModal({
-		collectionAddress,
-		chainId,
-		collectibleId,
-		orderbookKind,
-	});
-};
-
-return <button onClick={onClickOffer}>Make Offer</button>
 ```
 
-<ResponseField name="useMakeOfferModal">
-	<ResponseField name="* params"/>
-  <Expandable>
-		```ts
-		interface useMakeOfferModal {
-			onSuccess?: ({ hash, orderId }: {
-					hash?: Hash;
-					orderId?: string;
-			}) => void;
-			onError?: (error: Error) => void;
-		}
-		```
-  </Expandable>
-	<ResponseField name="* return properties"/>
-  <Expandable>
-    <ResponseField name="show" type="(args: ShowMakeOfferModalArgs) => void">
-		```ts
-		interface ShowMakeOfferModalArgs {
-			collectionAddress: Hex;
-			chainId: string;
-			collectibleId: string;
-			orderbookKind?: OrderbookKind;
-			callbacks?: ModalCallbacks;
-		}
-		```
-		</ResponseField>
-    <ResponseField name="close" type="() => void"></ResponseField>
-  </Expandable>
-</ResponseField>
+## Usage
+
+<Note>
+  Make sure you have followed the [Getting
+  Started](https://docs.sequence.xyz/sdk/marketplace-sdk/getting-started) guide
+  to get the collection address and chainId.
+</Note>
+
+### Example
+
+Example of implementing the make offer functionality using the `useMakeOfferModal` hook:
+
+```typescript
+export default function MakeOfferExample() {
+  const { data: marketplaceConfig, isLoading: isMarketplaceConfigLoading } =
+    useMarketplaceConfig();
+
+  const collection = marketplaceConfig?.market.collections[0];
+  const chainId = collection?.chainId as number;
+  const collectionAddress = collection?.itemsAddress as Address;
+  const collectibleId = '0';
+  const orderbookKind = collection?.destinationMarketplace;
+
+  const { show: showMakeOfferModal } = useMakeOfferModal({
+    onSuccess: ({ hash }) => {
+      console.log('Offer created successfully', { hash });
+    },
+    onError: (error) => {
+      console.error('Failed to create offer:', error.message);
+    },
+  });
+
+  const handleMakeOffer = () => {
+    showMakeOfferModal({
+      chainId,
+      collectionAddress,
+      collectibleId,
+      orderbookKind, // Optional - defaults to sequence_marketplace_v2
+    });
+  };
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h3>Make Offer</h3>
+
+      <button
+        type="button"
+        onClick={handleMakeOffer}
+        disabled={isMarketplaceConfigLoading}
+      >
+        Make Offer
+      </button>
+    </div>
+  );
+}
+```
+
+## Parameters
+
+The hook accepts an optional `callbacks` object with the following properties:
+
+```typescript
+interface ModalCallbacks {
+  onSuccess?: ({ hash, orderId }: { hash?: Hash; orderId?: string }) => void;
+  onError?: (error: Error) => void;
+  successActionButtons?: Array<{ label: string; action: () => void }>;
+}
+```
+
+| Parameter                        | Type                                                             | Description                                                                |
+| -------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `callbacks.onSuccess`            | `({ hash, orderId }: { hash?: Hash; orderId?: string }) => void` | Optional callback function called when the offer is created successfully   |
+| `callbacks.onError`              | `(error: Error) => void`                                         | Optional callback function called when an error occurs during offer creation |
+| `callbacks.successActionButtons` | `Array<{ label: string; action: () => void }>`                   | Optional array of action buttons to show on success                        |
+
+## Return Type
+
+The hook returns an object with the following methods:
+
+```typescript
+{
+  show: (args: ShowMakeOfferModalArgs) => void
+  close: () => void
+}
+```
+
+### Methods
+
+#### show
+
+`(args: ShowMakeOfferModalArgs) => void`
+
+Opens the make offer modal with the specified parameters.
+
+```typescript
+interface ShowMakeOfferModalArgs {
+  collectionAddress: Address;
+  chainId: number;
+  collectibleId: string;
+  orderbookKind?: OrderbookKind;
+}
+```
+
+| Parameter           | Type            | Description                                                                                        |
+| ------------------- | --------------- | -------------------------------------------------------------------------------------------------- |
+| `collectionAddress` | `Address`       | The contract address of the NFT collection                                                        |
+| `chainId`           | `number`        | The blockchain network chain ID where the collection exists                                       |
+| `collectibleId`     | `string`        | The token ID of the specific collectible to make an offer on                                      |
+| `orderbookKind`     | `OrderbookKind` | Optional. The marketplace orderbook to use (defaults to `sequence_marketplace_v2`)               |
+
+#### OrderbookKind Values
+
+```typescript
+enum OrderbookKind {
+  unknown = "unknown",
+  sequence_marketplace_v1 = "sequence_marketplace_v1",
+  sequence_marketplace_v2 = "sequence_marketplace_v2",
+  blur = "blur",
+  opensea = "opensea",
+  looks_rare = "looks_rare",
+}
+```
+
+#### close
+
+`() => void`
+
+Closes the make offer modal.
+
+## Notes
+
+The `useMakeOfferModal` hook provides a convenient way to manage the make offer modal interface for creating offers on collectibles. It handles:
+
+- Opening and closing the modal
+- Managing the offer creation flow state
+- Token approval for the offer currency (if required)
+- Error handling and success callbacks
+- Support for different marketplace orderbooks
+- Offer expiration date management (defaults to 7 days)
+- Currency selection and price input validation
+
+The modal allows users to:
+- Select the offer price and currency
+- Set the offer quantity (for ERC-1155 tokens)
+- Choose an expiration date for the offer
+- Complete the necessary blockchain transactions (approval + offer creation)


### PR DESCRIPTION
- Updated the documentation for the `useMakeOfferModal` hook to provide a clearer description and improved structure.
- Added detailed usage examples, including a complete implementation example for making offers on collectibles.
- Expanded the parameters section to include a comprehensive overview of the callbacks and return types.
- Included notes on the modal's functionality, such as offer price selection, quantity setting, and transaction management.