### PR TITLE
removed mentions of sardine from web sdk

### DIFF
--- a/es/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
+++ b/es/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
@@ -162,22 +162,22 @@ Función para abrir el modal de Selección de Pago con la configuración especif
 
 El objeto `settings` puede incluir las siguientes propiedades:
 
-| Parámetro               | Type                                         | Description                                                                               |
-| ----------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `collectibles`          | `Array<{tokenId: string, quantity: string}>` | Lista de coleccionables a comprar                                                         |
-| `chain`                 | `number`                                     | ID de la red blockchain                                                                   |
-| `price`                 | `string`                                     | Precio en la unidad más pequeña de la moneda                                              |
-| `targetContractAddress` | `string`                                     | Dirección del contrato con el que interactuar                                             |
-| `recipientAddress`      | `string`                                     | Dirección que recibirá los artículos comprados                                            |
-| `currencyAddress`       | `string`                                     | Dirección del contrato del token de la moneda                                             |
-| `collectionAddress`     | `string`                                     | Dirección del contrato de la colección NFT                                                |
-| `creditCardProviders`   | `string[]`                                   | Lista de proveedores de tarjeta de crédito soportados (por ejemplo, 'transak') |
-| `transakConfig`         | `object`                                     | Configuración para la integración con Transak                                             |
-| `copyrightText`         | `string`                                     | Texto de derechos de autor para mostrar en el modal                                       |
-| `onSuccess`             | `(txnHash: string) => void`                  | Callback cuando la transacción es exitosa                                                 |
-| `onError`               | `(error: Error) => void`                     | Callback cuando ocurre un error                                                           |
-| `onClose`               | `() => void`                                 | Callback cuando se cierra el modal                                                        |
-| `txData`                | `string`                                     | Datos de transacción codificados para la compra                                           |
+| Parámetro               | Tipo                                         | Descripción                                                                      |
+| ----------------------- | -------------------------------------------- | -------------------------------------------------------------------------------- |
+| `collectibles`          | `Array<{tokenId: string, quantity: string}>` | Lista de coleccionables a comprar                                                |
+| `chain`                 | `number`                                     | ID de la red blockchain                                                          |
+| `price`                 | `string`                                     | Precio en la unidad más pequeña de la moneda                                     |
+| `targetContractAddress` | `string`                                     | Dirección del contrato con el que interactuar                                    |
+| `recipientAddress`      | `string`                                     | Dirección que recibirá los artículos comprados                                   |
+| `currencyAddress`       | `string`                                     | Dirección del contrato del token de la moneda                                    |
+| `collectionAddress`     | `string`                                     | Dirección del contrato de la colección NFT                                       |
+| `creditCardProviders`   | `string[]`                                   | Lista de proveedores de tarjetas de crédito compatibles (por ejemplo, 'transak') |
+| `transakConfig`         | `object`                                     | Configuración para la integración con Transak                                    |
+| `copyrightText`         | `string`                                     | Texto de derechos de autor para mostrar en el modal                              |
+| `onSuccess`             | `(txnHash: string) => void`                  | Callback cuando la transacción es exitosa                                        |
+| `onError`               | `(error: Error) => void`                     | Callback cuando ocurre un error                                                  |
+| `onClose`               | `() => void`                                 | Callback cuando se cierra el modal                                               |
+| `txData`                | `string`                                     | Datos de transacción codificados para la compra                                  |
 
 #### closeSelectPaymentModal
 `() => void`

--- a/es/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
+++ b/es/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
@@ -110,7 +110,7 @@ function BuyNFT() {
             recipientAddress: address,
             currencyAddress,
             collectionAddress,
-            creditCardProviders: ['sardine', 'transak'],
+            creditCardProviders: ['transak'],
             transakConfig: {
                 contractId: 'your-contract-id',
                 apiKey: 'your-api-key'
@@ -171,7 +171,7 @@ El objeto `settings` puede incluir las siguientes propiedades:
 | `recipientAddress`      | `string`                                     | Dirección que recibirá los artículos comprados                                            |
 | `currencyAddress`       | `string`                                     | Dirección del contrato del token de la moneda                                             |
 | `collectionAddress`     | `string`                                     | Dirección del contrato de la colección NFT                                                |
-| `creditCardProviders`   | `string[]`                                   | Lista de proveedores de tarjeta de crédito soportados (por ejemplo, 'sardine', 'transak') |
+| `creditCardProviders`   | `string[]`                                   | Lista de proveedores de tarjeta de crédito soportados (por ejemplo, 'transak') |
 | `transakConfig`         | `object`                                     | Configuración para la integración con Transak                                             |
 | `copyrightText`         | `string`                                     | Texto de derechos de autor para mostrar en el modal                                       |
 | `onSuccess`             | `(txnHash: string) => void`                  | Callback cuando la transacción es exitosa                                                 |

--- a/es/sdk/web/wallet-sdk/embedded/guides/checkout.mdx
+++ b/es/sdk/web/wallet-sdk/embedded/guides/checkout.mdx
@@ -1,0 +1,195 @@
+---
+title: Modal de Checkout
+description: El Modal de Checkout ofrece a los desarrolladores una forma sencilla de implementar pagos con criptomonedas.
+sidebarTitle: Modal de Checkout
+---
+
+Sequence Checkout permite a los usuarios comprar fácilmente un token ERC721 o ERC1155 con un contrato de venta primaria o secundaria, como un marketplace, con las siguientes opciones de pago:
+- Comprar con cualquier criptomoneda en el wallet.
+- Recibir fondos desde otro wallet a un wallet de Sequence y comprar.
+- Pagar usando una tarjeta de crédito o débito, que detectará automáticamente el proveedor correcto según la región, la red y la moneda.
+- Pagar con otra criptomoneda en un wallet realizando un swap automático y la compra.
+
+Contamos con un flujo de checkout integrado que puede aprovechar instalando la librería dedicada `@0xsequence/checkout` y usándola junto con `@0xsequence/connect`.
+
+<Frame>
+  ![](/images/kit/checkout-modal.png)
+</Frame>
+
+<Note>
+  Para habilitar pagos con tarjeta de crédito en el checkout, por favor, contacte al equipo de Sequence ya que la dirección de su contrato deberá estar permitida (allowlisted) y su organización deberá pasar por un proceso KYB (Know Your Business). Los pagos con tarjeta de crédito solo funcionan en las mainnets de varias redes.
+</Note>
+
+# Instalación y configuración
+Para integrar la función de checkout, siga estos pasos:
+
+<Steps>
+  <Step title="Instale la librería `@0xsequence/checkout`:">
+    ```bash
+    npm install @0xsequence/checkout
+    # or
+    pnpm install @0xsequence/checkout
+    # or
+    yarn add @0xsequence/checkout
+    ```
+  </Step>
+
+  <Step title="Coloque el `SequenceCheckoutProvider` debajo del SequenceConnect Provider en su App:">
+    ```jsx
+    import { SequenceCheckoutProvider } from '@0xsequence/checkout'
+    import { SequenceConnect } from '@0xsequence/connect'
+    import { config } from './config'
+
+    const App = () => {
+      return (
+        <SequenceConnect config={config}>
+          <SequenceCheckoutProvider>
+            <Page />
+          </SequenceCheckoutProvider>
+        </SequenceConnect>
+      )
+    }
+    ```
+  </Step>
+</Steps>
+
+Ahora que hemos realizado la configuración, veamos cómo usar el modal de checkout para diferentes casos de uso.
+
+## Checkout con un token ERC1155
+Disponemos de funciones utilitarias para tokens ERC1155 que hacen más sencilla la configuración del modal de checkout.
+
+Aquí hay una configuración con variables de ejemplo:
+
+```jsx
+  import { useERC1155SaleContractCheckout } from "@0xsequence/checkout";
+  import { useAccount } from "wagmi";
+
+  const MyComponent = () => {
+    const { address: userAddress } = useAccount();
+    const { openCheckoutModal } = useERC1155SaleContractCheckout({
+      chain: 80002, // chainId of the chain the collectible is on
+      contractAddress: "0x0327b2f274e04d292e74a06809bcd687c63a4ba4", // address of the contract handling the minting function
+      wallet: userAddress!, // address of the recipient
+      collectionAddress: "0x888a322db4b8033bac3ff84412738c096f87f9d0", // address of the collection contract
+      items: [
+        // array of collectibles to purchase
+        {
+          tokenId: "0",
+          quantity: "1",
+        },
+      ],
+      onSuccess: (txnHash: string) => {
+        console.log("success!", txnHash);
+      },
+      onError: (error: Error) => {
+        console.error(error);
+      },
+    });
+
+    const onClick = () => {
+      if (!userAddress) {
+        return;
+      }
+      openCheckoutModal();
+    };
+
+    return <button onClick={onClick}>Buy ERC-1155 collectible!</button>;
+  };
+```
+
+## Contrato personalizado
+Instanciamos el hook `useSelectPaymentModal` para abrir el modal de checkout y pasar un objeto de configuración. Además, para contratos personalizados, puede especificar un ABI de contrato junto con la codificación de los datos de la llamada; en este caso estamos usando la utilidad `encodeFunctionData` de `ethers` y `viem`.
+
+```tsx
+import { useAccount } from 'wagmi'
+import { useSelectPaymentModal, type SelectPaymentSettings } from '@0xsequence/checkout'
+import { toHex } from 'viem'
+import { encodeFunctionData } from 'viem'
+
+const MyComponent = () => {
+    const { address } = useAccount()
+    const { openSelectPaymentModal } = useSelectPaymentModal()
+
+    const onClick = () => {
+        if (!address) {
+            return
+        }
+
+        const currencyAddress = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+        const salesContractAddress = '0xe65b75eb7c58ffc0bf0e671d64d0e1c6cd0d3e5b'
+        const collectionAddress = '0xdeb398f41ccd290ee5114df7e498cf04fac916cb'
+        const price = '20000'
+
+        const chainId = 137
+
+        const erc1155SalesContractAbi = [
+            {
+                type: 'function',
+                name: 'mint',
+                inputs: [
+                    { name: 'to', type: 'address', internalType: 'address' },
+                    { name: 'tokenIds', type: 'uint256[]', internalType: 'uint256[]' },
+                    { name: 'amounts', type: 'uint256[]', internalType: 'uint256[]' },
+                    { name: 'data', type: 'bytes', internalType: 'bytes' },
+                    { name: 'expectedPaymentToken', type: 'address', internalType: 'address' },
+                    { name: 'maxTotal', type: 'uint256', internalType: 'uint256' },
+                    { name: 'proof', type: 'bytes32[]', internalType: 'bytes32[]' }
+                ],
+                outputs: [],
+                stateMutability: 'payable'
+            }
+        ]
+
+        const collectibles = [
+            {
+                tokenId: '1',
+                quantity: '1'
+            }
+        ]
+
+        const purchaseTransactionData = encodeFunctionData({
+            abi: erc1155SalesContractAbi,
+            functionName: 'mint',
+            args: [
+                address,
+                collectibles.map(c => BigInt(c.tokenId)),
+                collectibles.map(c => BigInt(c.quantity)),
+                toHex(0),
+                currencyAddress,
+                price,
+                [toHex(0, { size: 32 })]
+            ]
+        })
+
+        const selectPaymentModalSettings: SelectPaymentSettings = {
+            collectibles: [
+                {
+                    tokenId: '1',
+                    quantity: '1'
+                }
+            ],
+            chain: chainId,
+            price,
+            targetContractAddress: salesContractAddress,
+            recipientAddress: address,
+            currencyAddress,
+            collectionAddress,
+            creditCardProviders: ['transak'],
+            copyrightText: 'ⓒ2024 Sequence',
+            onSuccess: (txnHash: string) => {
+                console.log('success!', txnHash)
+            },
+            onError: (error: Error) => {
+                console.error(error)
+            },
+            txData: purchaseTransactionData,
+        }
+
+        openSelectPaymentModal(selectPaymentModalSettings)
+    }
+
+    return <button onClick={onClick}>Buy ERC-1155 collectble!</button>
+}
+```
+
+¡Felicidades! Ahora sabe cómo usar el Modal de Checkout con Web SDK.

--- a/ja/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
+++ b/ja/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
@@ -110,7 +110,7 @@ function BuyNFT() {
             recipientAddress: address,
             currencyAddress,
             collectionAddress,
-            creditCardProviders: ['sardine', 'transak'],
+            creditCardProviders: ['transak'],
             transakConfig: {
                 contractId: 'your-contract-id',
                 apiKey: 'your-api-key'
@@ -171,7 +171,7 @@ type UseSelectPaymentModalReturnType = {
 | `recipientAddress`      | `string`                                     | 購入したアイテムの受取先アドレス                               |
 | `currencyAddress`       | `string`                                     | 通貨トークンコントラクトのアドレス                              |
 | `collectionAddress`     | `string`                                     | NFTコレクションコントラクトのアドレス                           |
-| `creditCardProviders`   | `string[]`                                   | 対応するクレジットカードプロバイダーのリスト（例：'sardine', 'transak'） |
+| `creditCardProviders`   | `string[]`                                   | 対応するクレジットカードプロバイダーのリスト（例：'transak'） |
 | `transakConfig`         | `object`                                     | Transak連携用の設定                                  |
 | `copyrightText`         | `string`                                     | モーダル内に表示する著作権テキスト                              |
 | `onSuccess`             | `(txnHash: string) => void`                  | トランザクションが成功した際のコールバック                          |

--- a/ja/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
+++ b/ja/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
@@ -162,22 +162,22 @@ type UseSelectPaymentModalReturnType = {
 
 `settings`オブジェクトには以下のプロパティを含めることができます:
 
-| パラメータ                   | 型                                            | 説明                                             |
-| ----------------------- | -------------------------------------------- | ---------------------------------------------- |
-| `collectibles`          | `Array<{tokenId: string, quantity: string}>` | 購入対象のコレクティブルの配列                                |
-| `chain`                 | `number`                                     | ブロックチェーンネットワークID                               |
-| `price`                 | `string`                                     | 通貨の最小単位での価格                                    |
-| `targetContractAddress` | `string`                                     | 操作対象となるコントラクトのアドレス                             |
-| `recipientAddress`      | `string`                                     | 購入したアイテムの受取先アドレス                               |
-| `currencyAddress`       | `string`                                     | 通貨トークンコントラクトのアドレス                              |
-| `collectionAddress`     | `string`                                     | NFTコレクションコントラクトのアドレス                           |
-| `creditCardProviders`   | `string[]`                                   | 対応するクレジットカードプロバイダーのリスト（例：'transak'） |
-| `transakConfig`         | `object`                                     | Transak連携用の設定                                  |
-| `copyrightText`         | `string`                                     | モーダル内に表示する著作権テキスト                              |
-| `onSuccess`             | `(txnHash: string) => void`                  | トランザクションが成功した際のコールバック                          |
-| `onError`               | `(error: Error) => void`                     | エラー発生時のコールバック                                  |
-| `onClose`               | `() => void`                                 | モーダルが閉じられたときのコールバック                            |
-| `txData`                | `string`                                     | 購入用のエンコード済みトランザクションデータ                         |
+| パラメータ                   | 型                                            | 説明                                  |
+| ----------------------- | -------------------------------------------- | ----------------------------------- |
+| `collectibles`          | `Array<{tokenId: string, quantity: string}>` | 購入対象のコレクティブルの配列                     |
+| `chain`                 | `number`                                     | ブロックチェーンネットワークID                    |
+| `price`                 | `string`                                     | 通貨の最小単位での価格                         |
+| `targetContractAddress` | `string`                                     | 操作対象となるコントラクトのアドレス                  |
+| `recipientAddress`      | `string`                                     | 購入したアイテムの受取先アドレス                    |
+| `currencyAddress`       | `string`                                     | 通貨トークンコントラクトのアドレス                   |
+| `collectionAddress`     | `string`                                     | NFTコレクションコントラクトのアドレス                |
+| `creditCardProviders`   | `string[]`                                   | 対応しているクレジットカードプロバイダー一覧（例：'transak'） |
+| `transakConfig`         | `object`                                     | Transak連携用の設定                       |
+| `copyrightText`         | `string`                                     | モーダル内に表示する著作権テキスト                   |
+| `onSuccess`             | `(txnHash: string) => void`                  | トランザクションが成功した際のコールバック               |
+| `onError`               | `(error: Error) => void`                     | エラー発生時のコールバック                       |
+| `onClose`               | `() => void`                                 | モーダルが閉じられたときのコールバック                 |
+| `txData`                | `string`                                     | 購入用のエンコード済みトランザクションデータ              |
 
 #### closeSelectPaymentModal
 `() => void`

--- a/ja/sdk/web/guides/checkout.mdx
+++ b/ja/sdk/web/guides/checkout.mdx
@@ -174,7 +174,7 @@ const MyComponent = () => {
             recipientAddress: address,
             currencyAddress,
             collectionAddress,
-            creditCardProviders: ['sardine'],
+            creditCardProviders: ['transak'],
             copyrightText: 'ⓒ2024 Sequence',
             onSuccess: (txnHash: string) => {
                 console.log('success!', txnHash)

--- a/ja/sdk/web/hooks/useSelectPaymentModal.mdx
+++ b/ja/sdk/web/hooks/useSelectPaymentModal.mdx
@@ -63,7 +63,7 @@ function App() {
       recipientAddress: address,
       currencyAddress,
       collectionAddress,
-      creditCardProviders: ['sardine', 'transak'],
+      creditCardProviders: ['transak'],
       transakConfig: {
         contractId: 'your-contract-id',
         apiKey: 'your-api-key'
@@ -121,7 +121,7 @@ type UseSelectPaymentModalReturnType = {
 | `recipientAddress`      | `string`                                     | 購入したアイテムの受取先アドレス                               |
 | `currencyAddress`       | `string`                                     | 通貨トークンコントラクトのアドレス                              |
 | `collectionAddress`     | `string`                                     | NFTコレクションコントラクトのアドレス                           |
-| `creditCardProviders`   | `string[]`                                   | 対応するクレジットカードプロバイダーのリスト（例：'sardine', 'transak'） |
+| `creditCardProviders`   | `string[]`                                   | 対応するクレジットカードプロバイダーのリスト（例： 'transak'） |
 | `transakConfig`         | `object`                                     | Transak連携用の設定                                  |
 | `copyrightText`         | `string`                                     | モーダル内に表示する著作権テキスト                              |
 | `onSuccess`             | `(txnHash: string) => void`                  | トランザクションが成功した際のコールバック                          |

--- a/ja/sdk/web/wallet-sdk/embedded/guides/checkout.mdx
+++ b/ja/sdk/web/wallet-sdk/embedded/guides/checkout.mdx
@@ -1,0 +1,195 @@
+---
+title: チェックアウトモーダル
+description: チェックアウトモーダルは、暗号資産決済を簡単に実装できる開発者向けの機能です。
+sidebarTitle: チェックアウトモーダル
+---
+
+Sequence Checkoutを使うと、ユーザーはマーケットプレイスなどの一次・二次販売コントラクトで、ERC721またはERC1155トークンを以下の方法で簡単に購入できます：
+- ウォレット内の任意の暗号資産で購入
+- 他のウォレットからSequenceウォレットに資金を受け取り、そのまま購入
+- クレジットカードやデビットカードで支払い（地域・チェーン・通貨ごとに最適なプロバイダーを自動判別）
+- ウォレット内の他の暗号資産を自動スワップして購入
+
+専用ライブラリ`@0xsequence/checkout`をインストールし、`@0xsequence/connect`と組み合わせて使うことで、統合されたチェックアウトフローを利用できます。
+
+<Frame>
+  ![](/images/kit/checkout-modal.png)
+</Frame>
+
+<Note>
+  チェックアウトでクレジットカード決済を有効にするには、Sequenceチームまでご連絡ください。コントラクトアドレスの許可リスト登録と、組織のKYB手続きが必要です。クレジットカード決済は一部ネットワークのメインネットのみ対応しています。
+</Note>
+
+# インストールとセットアップ
+チェックアウト機能を統合するには、以下の手順に従ってください：
+
+<Steps>
+  <Step title="`@0xsequence/checkout`ライブラリをインストールします：">
+    ```bash
+    npm install @0xsequence/checkout
+    # or
+    pnpm install @0xsequence/checkout
+    # or
+    yarn add @0xsequence/checkout
+    ```
+  </Step>
+
+  <Step title="アプリ内でSequenceConnect Providerの下に`SequenceCheckoutProvider`を配置します：">
+    ```jsx
+    import { SequenceCheckoutProvider } from '@0xsequence/checkout'
+    import { SequenceConnect } from '@0xsequence/connect'
+    import { config } from './config'
+
+    const App = () => {
+      return (
+        <SequenceConnect config={config}>
+          <SequenceCheckoutProvider>
+            <Page />
+          </SequenceCheckoutProvider>
+        </SequenceConnect>
+      )
+    }
+    ```
+  </Step>
+</Steps>
+
+セットアップが完了したら、さまざまなユースケースでチェックアウトモーダルを使う方法を見てみましょう。
+
+## ERC1155トークンでのチェックアウト
+ERC1155トークン用の便利なユーティリティ関数があり、チェックアウトモーダルの設定が簡単にできます。
+
+以下はサンプル変数を使った設定例です：
+
+```jsx
+  import { useERC1155SaleContractCheckout } from "@0xsequence/checkout";
+  import { useAccount } from "wagmi";
+
+  const MyComponent = () => {
+    const { address: userAddress } = useAccount();
+    const { openCheckoutModal } = useERC1155SaleContractCheckout({
+      chain: 80002, // chainId of the chain the collectible is on
+      contractAddress: "0x0327b2f274e04d292e74a06809bcd687c63a4ba4", // address of the contract handling the minting function
+      wallet: userAddress!, // address of the recipient
+      collectionAddress: "0x888a322db4b8033bac3ff84412738c096f87f9d0", // address of the collection contract
+      items: [
+        // array of collectibles to purchase
+        {
+          tokenId: "0",
+          quantity: "1",
+        },
+      ],
+      onSuccess: (txnHash: string) => {
+        console.log("success!", txnHash);
+      },
+      onError: (error: Error) => {
+        console.error(error);
+      },
+    });
+
+    const onClick = () => {
+      if (!userAddress) {
+        return;
+      }
+      openCheckoutModal();
+    };
+
+    return <button onClick={onClick}>Buy ERC-1155 collectible!</button>;
+  };
+```
+
+## カスタムコントラクト
+`useSelectPaymentModal`フックを使ってチェックアウトモーダルを開き、設定オブジェクトを渡します。カスタムコントラクトの場合は、コントラクトABIやコールデータのエンコードも指定できます（この例では`ethers`や`viem`の`encodeFunctionData`ユーティリティを使用）。
+
+```tsx
+import { useAccount } from 'wagmi'
+import { useSelectPaymentModal, type SelectPaymentSettings } from '@0xsequence/checkout'
+import { toHex } from 'viem'
+import { encodeFunctionData } from 'viem'
+
+const MyComponent = () => {
+    const { address } = useAccount()
+    const { openSelectPaymentModal } = useSelectPaymentModal()
+
+    const onClick = () => {
+        if (!address) {
+            return
+        }
+
+        const currencyAddress = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+        const salesContractAddress = '0xe65b75eb7c58ffc0bf0e671d64d0e1c6cd0d3e5b'
+        const collectionAddress = '0xdeb398f41ccd290ee5114df7e498cf04fac916cb'
+        const price = '20000'
+
+        const chainId = 137
+
+        const erc1155SalesContractAbi = [
+            {
+                type: 'function',
+                name: 'mint',
+                inputs: [
+                    { name: 'to', type: 'address', internalType: 'address' },
+                    { name: 'tokenIds', type: 'uint256[]', internalType: 'uint256[]' },
+                    { name: 'amounts', type: 'uint256[]', internalType: 'uint256[]' },
+                    { name: 'data', type: 'bytes', internalType: 'bytes' },
+                    { name: 'expectedPaymentToken', type: 'address', internalType: 'address' },
+                    { name: 'maxTotal', type: 'uint256', internalType: 'uint256' },
+                    { name: 'proof', type: 'bytes32[]', internalType: 'bytes32[]' }
+                ],
+                outputs: [],
+                stateMutability: 'payable'
+            }
+        ]
+
+        const collectibles = [
+            {
+                tokenId: '1',
+                quantity: '1'
+            }
+        ]
+
+        const purchaseTransactionData = encodeFunctionData({
+            abi: erc1155SalesContractAbi,
+            functionName: 'mint',
+            args: [
+                address,
+                collectibles.map(c => BigInt(c.tokenId)),
+                collectibles.map(c => BigInt(c.quantity)),
+                toHex(0),
+                currencyAddress,
+                price,
+                [toHex(0, { size: 32 })]
+            ]
+        })
+
+        const selectPaymentModalSettings: SelectPaymentSettings = {
+            collectibles: [
+                {
+                    tokenId: '1',
+                    quantity: '1'
+                }
+            ],
+            chain: chainId,
+            price,
+            targetContractAddress: salesContractAddress,
+            recipientAddress: address,
+            currencyAddress,
+            collectionAddress,
+            creditCardProviders: ['transak'],
+            copyrightText: 'ⓒ2024 Sequence',
+            onSuccess: (txnHash: string) => {
+                console.log('success!', txnHash)
+            },
+            onError: (error: Error) => {
+                console.error(error)
+            },
+            txData: purchaseTransactionData,
+        }
+
+        openSelectPaymentModal(selectPaymentModalSettings)
+    }
+
+    return <button onClick={onClick}>Buy ERC-1155 collectble!</button>
+}
+```
+
+おめでとうございます！これでWeb SDKでチェックアウトモーダルを使う方法が習得できました。

--- a/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
+++ b/sdk/web/checkout-sdk/hooks/useSelectPaymentModal.mdx
@@ -111,7 +111,7 @@ function BuyNFT() {
             recipientAddress: address,
             currencyAddress,
             collectionAddress,
-            creditCardProviders: ['sardine', 'transak'],
+            creditCardProviders: ['transak'],
             transakConfig: {
                 contractId: 'your-contract-id',
                 apiKey: 'your-api-key'
@@ -174,7 +174,7 @@ The `settings` object can include the following properties:
 | `recipientAddress` | `string` | Address to receive the purchased items |
 | `currencyAddress` | `string` | Address of the currency token contract |
 | `collectionAddress` | `string` | Address of the NFT collection contract |
-| `creditCardProviders` | `string[]` | List of supported credit card providers (e.g., 'sardine', 'transak') |
+| `creditCardProviders` | `string[]` | List of supported credit card providers (e.g., 'transak') |
 | `transakConfig` | `object` | Configuration for Transak integration |
 | `copyrightText` | `string` | Copyright text to display in the modal |
 | `onSuccess` | `(txnHash: string) => void` | Callback when transaction succeeds |

--- a/sdk/web/wallet-sdk/embedded/guides/checkout.mdx
+++ b/sdk/web/wallet-sdk/embedded/guides/checkout.mdx
@@ -177,7 +177,7 @@ Here's a configuration with example variables:
               recipientAddress: address,
               currencyAddress,
               collectionAddress,
-              creditCardProviders: ['sardine'],
+              creditCardProviders: ['transak'],
               copyrightText: 'ⓒ2024 Sequence',
               onSuccess: (txnHash: string) => {
                   console.log('success!', txnHash)


### PR DESCRIPTION
Due to deprecation of sardine in the web-sdk, we are removing mentions of sardine from the web sdk's docs.